### PR TITLE
chore: add column for pin

### DIFF
--- a/migration/2.10.0.sql
+++ b/migration/2.10.0.sql
@@ -1,0 +1,6 @@
+-- Add a field to store [hashed] user pins. We default to NULL indicating no pin
+-- has been set.
+
+ALTER TABLE users ADD COLUMN pin VARCHAR(255) NULL DEFAULT NULL;
+
+INSERT INTO schema_versioning(version, comment) VALUES ("2.10.0", "Migration Complete");

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -238,6 +238,7 @@ CREATE TABLE users (
 	comment TEXT,
 	role_id INT UNSIGNED NOT NULL,
 	is_active INT(1) UNSIGNED NOT NULL,
+	pin VARCHAR(255) NULL DEFAULT NULL,
 	PRIMARY KEY (id),
 	UNIQUE KEY users_email (email),
 	FOREIGN KEY users_role_id (role_id) REFERENCES roles (id)


### PR DESCRIPTION
This PR if accepted adds a column for the user pin. @AxelAndrews Unlike the 24-25 senior design I have sized it to store a hashed value and defaulted it to `NULL` for no password.